### PR TITLE
`ansi_rgb` 0.3.2-alpha

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,9 +16,9 @@ checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
 name = "ansi_rgb"
-version = "0.2.0"
+version = "0.3.2-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a730095eb14ee842a0f1e68504b85c8d4a19b1ef2ac2a9b4debf0ed982f9b08a"
+checksum = "9f2916ece1f4834fa424632f76e3a93e677de5fd05dbbf5680bbbc4ab6058ad9"
 dependencies = [
  "rgb",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,5 @@ tokio = { version = "1", features = ["full"] }
 eyre = "0.6"
 seahorse = "2.0.0"
 byte-unit = "4.0"
-ansi_rgb = "0.2"
+ansi_rgb = "0.3.2-alpha"
 rgb = "0.8"

--- a/src/image.rs
+++ b/src/image.rs
@@ -1,5 +1,5 @@
 use crate::utils::ImageMode;
-use ansi_rgb::Background;
+use ansi_rgb::Colorable;
 use image::{DynamicImage, GenericImageView, LumaA, Rgba};
 use rgb::RGB8;
 


### PR DESCRIPTION
Hello! I have released [`ansi_rgb` 0.3.2-alpha](https://crates.io/crates/ansi_rgb/0.3.2-alpha). Would you be willing to try it out and let me know what you think?

I think this will have minimal impact on your existing code. I haven't fully tested your code, but as you can see with this PR the changes are very minimal.

0.3.2 makes it much easier to use the `.fg` and `.bg` functions [with custom color types](https://docs.rs/ansi_rgb/0.3.2-alpha/ansi_rgb/index.html#extending-to-other-color-types) that you can define privately in your own crate. So it should be easier to extend should the need arise.

0.3.2 also supports [3-](https://docs.rs/ansi_rgb/0.3.2-alpha/ansi_rgb/index.html#3-bit-colors), [4-](https://docs.rs/ansi_rgb/0.3.2-alpha/ansi_rgb/index.html#4-bit-colors), and [8-](https://docs.rs/ansi_rgb/0.3.2-alpha/ansi_rgb/index.html#8-bit-colors) bit colors.

If you like the alpha then I can keep you posted as 0.3.2 goes through beta -> release.